### PR TITLE
fix: changed db.entities to cds.entities - for future use

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -93,7 +93,7 @@ const bindEntity = async (service, entity) => {
 const createCacheEntry = async (cacheName, serviceConfig = {}) => {
     try {
         const db = await cds.connect.to('db');
-        const { Caches } = db.entities('plugin.cds_caching');
+        const { Caches } = cds.entities('plugin.cds_caching');
 
         // Check if cache entry already exists
         const existingCache = await db.read(Caches).where({ name: cacheName });


### PR DESCRIPTION
to get rid of the following warning:
```shell
DEPRECATED: srv.entities()
API srv.entities() is deprecated and will be removed in upcoming releases!
=> Please use cds.entities() instead.
at createCacheEntry (/my-project/node_modules/cds-caching/lib/util.js:96:31)
at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
at async cds.scanCachingAnnotations (/my-project/node_modules/cds-caching/lib/util.js:197:9)
at async cds.cds_server [as server] (/my-project/node_modules/@sap/cds/server.js:61:3)
at async serve (/my-project/node_modules/@sap/cds/bin/serve.js:208:18)
```