### PR TITLE
fix: prevent NaN on HANA metrics hourly-stats UPDATE (#27)

### DIFF
--- a/lib/support/StatisticsPersistenceManager.js
+++ b/lib/support/StatisticsPersistenceManager.js
@@ -37,13 +37,14 @@ class StatisticsPersistenceManager {
         }
 
         try {
-            const existingHourly = await SELECT.one.from("plugin_cds_caching_Metrics")
+            const { Metrics } = cds.entities('plugin.cds_caching');
+            const existingHourly = await SELECT.one.from(Metrics)
                 .where({ ID: hourlyId, cache: this.cacheName });
 
             if (!existingHourly) {
-                await this._createHourlyStats(stats, hourlyId, hourlyTimestamp);
+                await this._createHourlyStats(Metrics, stats, hourlyId, hourlyTimestamp);
             } else {
-                await this._updateHourlyStats(stats, hourlyId, existingHourly);
+                await this._updateHourlyStats(Metrics, stats, hourlyId, existingHourly);
             }
         } catch (error) {
             this.log.error(`Failed to persist hourly stats for cache ${this.cacheName}:`, error);
@@ -66,9 +67,10 @@ class StatisticsPersistenceManager {
 
         this.log.debug(`Persisting ${keyAccess.size} key access records for cache ${this.cacheName}`);
 
+        const { KeyMetrics } = cds.entities('plugin.cds_caching');
         for (const [key, keyStats] of keyAccess) {
             try {
-                await this._persistKeyMetric(key, keyStats);
+                await this._persistKeyMetric(KeyMetrics, key, keyStats);
             } catch (error) {
                 this.log.error(`Failed to persist key metric for key ${key}:`, error);
             }
@@ -101,8 +103,8 @@ class StatisticsPersistenceManager {
      * Create new hourly stats record
      * @private
      */
-    async _createHourlyStats(stats, hourlyId, hourlyTimestamp) {
-        await INSERT.into('plugin_cds_caching_Metrics').entries([{
+    async _createHourlyStats(Metrics, stats, hourlyId, hourlyTimestamp) {
+        await INSERT.into(Metrics).entries([{
             ID: hourlyId,
             cache: this.cacheName,
             timestamp: hourlyTimestamp,
@@ -153,10 +155,10 @@ class StatisticsPersistenceManager {
      * Update existing hourly stats record
      * @private
      */
-    async _updateHourlyStats(stats, hourlyId, existingHourly) {
+    async _updateHourlyStats(Metrics, stats, hourlyId, existingHourly) {
         const updatedStats = this._calculateUpdatedStats(stats, existingHourly);
 
-        await UPDATE('plugin_cds_caching_Metrics')
+        await UPDATE(Metrics)
             .set(updatedStats)
             .where({ ID: hourlyId, cache: this.cacheName });
         this.log.debug(`Updated existing hourly stats for cache ${this.cacheName}`);
@@ -169,19 +171,19 @@ class StatisticsPersistenceManager {
     _calculateUpdatedStats(stats, existingHourly) {
         const updatedStats = {
             // Read-through metrics
-            hits: existingHourly.hits + stats.hits,
-            misses: existingHourly.misses + stats.misses,
-            errors: existingHourly.errors + stats.errors,
-            totalRequests: existingHourly.totalRequests + stats.totalRequests,
+            hits: (Number(existingHourly.hits) || 0) + stats.hits,
+            misses: (Number(existingHourly.misses) || 0) + stats.misses,
+            errors: (Number(existingHourly.errors) || 0) + stats.errors,
+            totalRequests: (Number(existingHourly.totalRequests) || 0) + stats.totalRequests,
 
             // Native function metrics
-            nativeSets: existingHourly.nativeSets + stats.nativeSets,
-            nativeGets: existingHourly.nativeGets + stats.nativeGets,
-            nativeDeletes: existingHourly.nativeDeletes + stats.nativeDeletes,
-            nativeClears: existingHourly.nativeClears + stats.nativeClears,
-            nativeDeleteByTags: existingHourly.nativeDeleteByTags + stats.nativeDeleteByTags,
-            nativeErrors: existingHourly.nativeErrors + stats.nativeErrors,
-            totalNativeOperations: existingHourly.totalNativeOperations + stats.totalNativeOperations,
+            nativeSets: (Number(existingHourly.nativeSets) || 0) + stats.nativeSets,
+            nativeGets: (Number(existingHourly.nativeGets) || 0) + stats.nativeGets,
+            nativeDeletes: (Number(existingHourly.nativeDeletes) || 0) + stats.nativeDeletes,
+            nativeClears: (Number(existingHourly.nativeClears) || 0) + stats.nativeClears,
+            nativeDeleteByTags: (Number(existingHourly.nativeDeleteByTags) || 0) + stats.nativeDeleteByTags,
+            nativeErrors: (Number(existingHourly.nativeErrors) || 0) + stats.nativeErrors,
+            totalNativeOperations: (Number(existingHourly.totalNativeOperations) || 0) + stats.totalNativeOperations,
 
             // Common metrics
             memoryUsage: stats.memoryUsage,
@@ -194,7 +196,7 @@ class StatisticsPersistenceManager {
 
         // Weighted average for hit latency
         if (updatedStats.hits > 0) {
-            const existingHitLatencySum = existingHourly.avgHitLatency * existingHourly.hits;
+            const existingHitLatencySum = (Number(existingHourly.avgHitLatency) || 0) * (Number(existingHourly.hits) || 0);
             const newHitLatencySum = stats.avgHitLatency * stats.hits;
             updatedStats.avgHitLatency = (existingHitLatencySum + newHitLatencySum) / updatedStats.hits;
         } else {
@@ -203,7 +205,7 @@ class StatisticsPersistenceManager {
 
         // Weighted average for miss latency
         if (updatedStats.misses > 0) {
-            const existingMissLatencySum = existingHourly.avgMissLatency * existingHourly.misses;
+            const existingMissLatencySum = (Number(existingHourly.avgMissLatency) || 0) * (Number(existingHourly.misses) || 0);
             const newMissLatencySum = stats.avgMissLatency * stats.misses;
             updatedStats.avgMissLatency = (existingMissLatencySum + newMissLatencySum) / updatedStats.misses;
         } else {
@@ -211,12 +213,12 @@ class StatisticsPersistenceManager {
         }
 
         // Weighted average for read-through latency (combined hits and misses)
-        const existingCount = (existingHourly.hits || 0) + (existingHourly.misses || 0);
+        const existingCount = (Number(existingHourly.hits) || 0) + (Number(existingHourly.misses) || 0);
         const newCount = (stats.hits || 0) + (stats.misses || 0);
         const totalCount = existingCount + newCount;
         if (totalCount > 0) {
             updatedStats.avgReadThroughLatency =
-                ((existingHourly.avgReadThroughLatency || 0) * existingCount +
+                ((Number(existingHourly.avgReadThroughLatency) || 0) * existingCount +
                  (stats.avgReadThroughLatency || 0) * newCount) / totalCount;
         } else {
             updatedStats.avgReadThroughLatency = 0;
@@ -242,10 +244,10 @@ class StatisticsPersistenceManager {
         }
 
         // Update percentiles (use max/min of existing and current, with min using mergeMin)
-        updatedStats.maxHitLatency = Math.max(existingHourly.maxHitLatency || 0, stats.maxHitLatency || 0);
-        updatedStats.maxMissLatency = Math.max(existingHourly.maxMissLatency || 0, stats.maxMissLatency || 0);
-        updatedStats.minHitLatency = mergeMin(existingHourly.minHitLatency, stats.minHitLatency);
-        updatedStats.minMissLatency = mergeMin(existingHourly.minMissLatency, stats.minMissLatency);
+        updatedStats.maxHitLatency = Math.max(Number(existingHourly.maxHitLatency) || 0, stats.maxHitLatency || 0);
+        updatedStats.maxMissLatency = Math.max(Number(existingHourly.maxMissLatency) || 0, stats.maxMissLatency || 0);
+        updatedStats.minHitLatency = mergeMin(Number(existingHourly.minHitLatency) || 0, stats.minHitLatency);
+        updatedStats.minMissLatency = mergeMin(Number(existingHourly.minMissLatency) || 0, stats.minMissLatency);
 
         return updatedStats;
     }
@@ -254,16 +256,16 @@ class StatisticsPersistenceManager {
      * Persist a single key metric
      * @private
      */
-    async _persistKeyMetric(key, keyStats) {
+    async _persistKeyMetric(KeyMetrics, key, keyStats) {
         const keyId = `key:${this.cacheName}:${key}`;
 
-        const existingKey = await SELECT.one.from("plugin_cds_caching_KeyMetrics")
+        const existingKey = await SELECT.one.from(KeyMetrics)
             .where({ ID: keyId, cache: this.cacheName, keyName: key });
 
         if (!existingKey) {
-            await this._createKeyMetric(key, keyStats, keyId);
+            await this._createKeyMetric(KeyMetrics, key, keyStats, keyId);
         } else {
-            await this._updateKeyMetric(key, keyStats, keyId, existingKey);
+            await this._updateKeyMetric(KeyMetrics, key, keyStats, keyId, existingKey);
         }
     }
 
@@ -271,9 +273,9 @@ class StatisticsPersistenceManager {
      * Create new key metric record
      * @private
      */
-    async _createKeyMetric(key, keyStats, keyId) {
+    async _createKeyMetric(KeyMetrics, key, keyStats, keyId) {
 
-        await INSERT.into('plugin_cds_caching_KeyMetrics').entries([{
+        await INSERT.into(KeyMetrics).entries([{
             ID: keyId,
             cache: this.cacheName,
             keyName: key,
@@ -339,41 +341,41 @@ class StatisticsPersistenceManager {
      * Update existing key metric record
      * @private
      */
-    async _updateKeyMetric(key, keyStats, keyId, existingKey) {
-        const totalHits = existingKey.hits + keyStats.hits;
-        const totalMisses = existingKey.misses + keyStats.misses;
+    async _updateKeyMetric(KeyMetrics, key, keyStats, keyId, existingKey) {
+        const totalHits = (Number(existingKey.hits) || 0) + keyStats.hits;
+        const totalMisses = (Number(existingKey.misses) || 0) + keyStats.misses;
 
         const updatedKeyStats = {
             hits: totalHits,
             misses: totalMisses,
-            errors: (existingKey.errors || 0) + (keyStats.errors || 0),
+            errors: (Number(existingKey.errors) || 0) + (keyStats.errors || 0),
             totalRequests: totalHits + totalMisses,
             lastAccess: new Date(keyStats.lastAccess).toISOString(),
 
             // Native function metrics
-            nativeHits: (existingKey.nativeHits || 0) + (keyStats.nativeHits || 0),
-            nativeMisses: (existingKey.nativeMisses || 0) + (keyStats.nativeMisses || 0),
-            nativeSets: (existingKey.nativeSets || 0) + (keyStats.nativeSets || 0),
-            nativeDeletes: (existingKey.nativeDeletes || 0) + (keyStats.nativeDeletes || 0),
-            nativeClears: (existingKey.nativeClears || 0) + (keyStats.nativeClears || 0),
-            nativeDeleteByTags: (existingKey.nativeDeleteByTags || 0) + (keyStats.nativeDeleteByTags || 0),
-            nativeErrors: (existingKey.nativeErrors || 0) + (keyStats.nativeErrors || 0),
-            totalNativeOperations: (existingKey.totalNativeOperations || 0) + (keyStats.totalNativeOperations || 0),
+            nativeHits: (Number(existingKey.nativeHits) || 0) + (keyStats.nativeHits || 0),
+            nativeMisses: (Number(existingKey.nativeMisses) || 0) + (keyStats.nativeMisses || 0),
+            nativeSets: (Number(existingKey.nativeSets) || 0) + (keyStats.nativeSets || 0),
+            nativeDeletes: (Number(existingKey.nativeDeletes) || 0) + (keyStats.nativeDeletes || 0),
+            nativeClears: (Number(existingKey.nativeClears) || 0) + (keyStats.nativeClears || 0),
+            nativeDeleteByTags: (Number(existingKey.nativeDeleteByTags) || 0) + (keyStats.nativeDeleteByTags || 0),
+            nativeErrors: (Number(existingKey.nativeErrors) || 0) + (keyStats.nativeErrors || 0),
+            totalNativeOperations: (Number(existingKey.totalNativeOperations) || 0) + (keyStats.totalNativeOperations || 0),
 
             // Weighted average for hit latency
             avgHitLatency: totalHits > 0
-                ? ((existingKey.avgHitLatency * existingKey.hits) + (keyStats.avgHitLatency * keyStats.hits)) / totalHits
+                ? (((Number(existingKey.avgHitLatency) || 0) * (Number(existingKey.hits) || 0)) + (keyStats.avgHitLatency * keyStats.hits)) / totalHits
                 : 0,
             // Weighted average for miss latency
             avgMissLatency: totalMisses > 0
-                ? ((existingKey.avgMissLatency * existingKey.misses) + (keyStats.avgMissLatency * keyStats.misses)) / totalMisses
+                ? (((Number(existingKey.avgMissLatency) || 0) * (Number(existingKey.misses) || 0)) + (keyStats.avgMissLatency * keyStats.misses)) / totalMisses
                 : 0,
 
             // Update percentiles (use max/min of existing and current, with min using mergeMin)
-            minHitLatency: mergeMin(existingKey.minHitLatency, keyStats.minHitLatency),
-            maxHitLatency: Math.max(existingKey.maxHitLatency || 0, keyStats.maxHitLatency || 0),
-            minMissLatency: mergeMin(existingKey.minMissLatency, keyStats.minMissLatency),
-            maxMissLatency: Math.max(existingKey.maxMissLatency || 0, keyStats.maxMissLatency || 0)
+            minHitLatency: mergeMin(Number(existingKey.minHitLatency) || 0, keyStats.minHitLatency),
+            maxHitLatency: Math.max(Number(existingKey.maxHitLatency) || 0, keyStats.maxHitLatency || 0),
+            minMissLatency: mergeMin(Number(existingKey.minMissLatency) || 0, keyStats.minMissLatency),
+            maxMissLatency: Math.max(Number(existingKey.maxMissLatency) || 0, keyStats.maxMissLatency || 0)
         };
 
         // Update context information if new data is available
@@ -385,7 +387,7 @@ class StatisticsPersistenceManager {
         if (keyStats.user) updatedKeyStats.user = keyStats.user;
         if (keyStats.locale) updatedKeyStats.locale = keyStats.locale;
         if (keyStats.cacheOptions) updatedKeyStats.cacheOptions = keyStats.cacheOptions;    
-        await UPDATE('plugin_cds_caching_KeyMetrics')
+        await UPDATE(KeyMetrics)
             .set(updatedKeyStats)
             .where({ ID: keyId, cache: this.cacheName, keyName: key });
     }

--- a/test/StatisticsPersistence.test.js
+++ b/test/StatisticsPersistence.test.js
@@ -1,0 +1,120 @@
+const StatisticsPersistenceManager = require('../lib/support/StatisticsPersistenceManager');
+
+// Regression test for issue #27: on HANA the read-back of an existing metrics
+// row returns UPPERCASE column keys (HITS, MISSES, ...). The accumulation code
+// reads camelCase properties, so `undefined + number` used to yield NaN, which
+// hdb rejects when binding into an INT column ("Wrong input for INT type").
+// The Number(existing?.x) || 0 guards in _calculateUpdatedStats / _updateKeyMetric
+// must keep every accumulator a finite number regardless of key casing.
+
+const noopLog = { debug() {}, error() {}, warn() {}, info() {} };
+
+function makeStats(overrides = {}) {
+    return {
+        hits: 5,
+        misses: 3,
+        errors: 1,
+        totalRequests: 8,
+        avgHitLatency: 10,
+        minHitLatency: 5,
+        maxHitLatency: 20,
+        avgMissLatency: 40,
+        minMissLatency: 30,
+        maxMissLatency: 60,
+        avgReadThroughLatency: 25,
+        hitRatio: 0,
+        throughput: 0,
+        errorRate: 0,
+        cacheEfficiency: 0,
+        nativeSets: 2,
+        nativeGets: 4,
+        nativeDeletes: 1,
+        nativeClears: 0,
+        nativeDeleteByTags: 0,
+        nativeErrors: 0,
+        totalNativeOperations: 7,
+        nativeThroughput: 0,
+        nativeErrorRate: 0,
+        memoryUsage: 1000,
+        itemCount: 3,
+        uptimeMs: 10000,
+        ...overrides,
+    };
+}
+
+const INT_FIELDS = [
+    'hits', 'misses', 'errors', 'totalRequests',
+    'nativeSets', 'nativeGets', 'nativeDeletes', 'nativeClears',
+    'nativeDeleteByTags', 'nativeErrors', 'totalNativeOperations',
+    'memoryUsage', 'itemCount', 'uptimeMs',
+];
+
+describe('StatisticsPersistenceManager accumulation (issue #27)', () => {
+
+    let manager;
+
+    beforeEach(() => {
+        manager = new StatisticsPersistenceManager('test-cache', noopLog);
+    });
+
+    describe('_calculateUpdatedStats', () => {
+
+        it('keeps all INT accumulators finite when the existing row has UPPERCASE keys (HANA)', () => {
+            const stats = makeStats();
+            // Simulate HANA read-back: only UPPERCASE keys are present.
+            const existingUpper = {
+                HITS: 10, MISSES: 4, ERRORS: 2, TOTALREQUESTS: 14,
+                NATIVESETS: 3, NATIVEGETS: 6, NATIVEDELETES: 1, NATIVECLEARS: 0,
+                NATIVEDELETEBYTAGS: 0, NATIVEERRORS: 0, TOTALNATIVEOPERATIONS: 10,
+                AVGHITLATENCY: 12, MINHITLATENCY: 4, MAXHITLATENCY: 25,
+                AVGMISSLATENCY: 50, MINMISSLATENCY: 20, MAXMISSLATENCY: 70,
+                AVGREADTHROUGHLATENCY: 30,
+            };
+
+            const result = manager._calculateUpdatedStats(stats, existingUpper);
+
+            for (const [field, value] of Object.entries(result)) {
+                expect(Number.isNaN(value), `${field} should not be NaN`).toBe(false);
+            }
+            // Without camelCase keys the guards treat existing as 0, so INT
+            // accumulators equal the incoming stats values (still finite).
+            for (const field of INT_FIELDS) {
+                expect(Number.isFinite(result[field]), `${field} should be finite`).toBe(true);
+            }
+            expect(result.hits).toBe(stats.hits);
+            expect(result.totalNativeOperations).toBe(stats.totalNativeOperations);
+        });
+
+        it('accumulates correctly when the existing row has camelCase keys (SQLite/entity read)', () => {
+            const stats = makeStats();
+            const existing = {
+                hits: 10, misses: 4, errors: 2, totalRequests: 14,
+                nativeSets: 3, nativeGets: 6, nativeDeletes: 1, nativeClears: 0,
+                nativeDeleteByTags: 0, nativeErrors: 0, totalNativeOperations: 10,
+                avgHitLatency: 12, minHitLatency: 4, maxHitLatency: 25,
+                avgMissLatency: 50, minMissLatency: 20, maxMissLatency: 70,
+                avgReadThroughLatency: 30,
+            };
+
+            const result = manager._calculateUpdatedStats(stats, existing);
+
+            expect(result.hits).toBe(15);
+            expect(result.misses).toBe(7);
+            expect(result.errors).toBe(3);
+            expect(result.totalRequests).toBe(22);
+            expect(result.totalNativeOperations).toBe(17);
+            for (const [field, value] of Object.entries(result)) {
+                expect(Number.isNaN(value), `${field} should not be NaN`).toBe(false);
+            }
+        });
+
+        it('tolerates a completely empty existing row without producing NaN', () => {
+            const stats = makeStats();
+            const result = manager._calculateUpdatedStats(stats, {});
+            for (const [field, value] of Object.entries(result)) {
+                expect(Number.isNaN(value), `${field} should not be NaN`).toBe(false);
+            }
+            expect(result.hits).toBe(stats.hits);
+        });
+    });
+});


### PR DESCRIPTION
Query Metrics/KeyMetrics via resolved CSN entities so CAP returns camelCase keys on HANA, and coerce existing accumulators with Number(...) || 0 to avoid NaN into INT columns.