### PR TITLE
Security hardening for 2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Please also read the introduction blog post: [Boosting performance in SAP Cloud 
 | [Programmatic API](docs/programmatic-api.md) | Full API reference for cache operations |
 | [Protocol Support](docs/protocols.md) | Caching across OData, REST, GraphQL, HCQL, and MCP |
 | [Key Management](docs/key-management.md) | Key templates, context awareness, custom keys |
+| [Security](docs/security.md) | Authorization, cache key isolation, production checklist |
 | [Metrics Guide](docs/metrics-guide.md) | Statistics, monitoring, and performance tracking |
 | [OpenTelemetry Integration](docs/telemetry.md) | Distributed tracing and metrics export |
 | [OData API](docs/odata-api.md) | REST endpoints for management and monitoring |
@@ -260,11 +261,13 @@ See **[Feature Activation](docs/feature-activation.md)** for reuse vs own activa
 | BTP with HTML5 repo | `cds add caching-metrics` + `metrics.enabled` — no `metrics.reuse.dashboard` |
 | API only, no UI | `metrics.reuse.api` or `using … index.cds` + `metrics.enabled` |
 
-Restrict access with a fully-qualified annotate — do **not** repeat the `using` import:
+The API requires an authenticated user by default. Restrict it to an administrative role with a fully-qualified annotate — do **not** repeat the `using` import:
 
 ```cds
-annotate plugin.cds_caching.CachingApiService with @requires: 'authenticated-user';
+annotate plugin.cds_caching.CachingApiService with @requires: 'CacheAdmin';
 ```
+
+See the [Security Guide](docs/security.md) for the production checklist, including cache key isolation for user-filtered data.
 
 ## Multi-Tenancy (MTX)
 

--- a/cds-plugin.js
+++ b/cds-plugin.js
@@ -35,7 +35,16 @@ if (reuseDashboard) {
         );
     }
     cds.once('bootstrap', (app) => {
-        app.use('/caching-dashboard', require('express').static(dashboardPath));
+        // Run CAP's middlewares first so cds.context.user is populated, then gate
+        // the static assets on it.
+        const { requireAuthenticatedUser, capRequestMiddlewares } = require('./lib/dashboard-guard');
+
+        app.use(
+            '/caching-dashboard',
+            ...capRequestMiddlewares(),
+            requireAuthenticatedUser,
+            require('express').static(dashboardPath)
+        );
         (app._app_links ??= []).push('/caching-dashboard');
         LOG.info("Serving cds-caching dashboard at /caching-dashboard");
     });

--- a/cds-plugin.js
+++ b/cds-plugin.js
@@ -56,7 +56,6 @@ cds.build?.register?.('cds-caching', class CachingBuildPlugin extends cds.build.
     clean() { }
 
     static hasTask() {
-        cds.log('cds-caching').info('hasTask', cds.env.requires);
         const requires = cds.env.requires || {};
         const dbKind = requires.db?.kind || '';
         const isHanaDB = dbKind === 'hana' || dbKind === 'sql';

--- a/cds-plugin.js
+++ b/cds-plugin.js
@@ -2,10 +2,24 @@ const cds = require('@sap/cds')
 const { fs, path } = cds.utils;
 const CachingService = require('./lib/CachingService')
 const { scanCachingAnnotations } = require('./lib/util')
-const { getCachingRequiresEntries } = require('./lib/config-normalizer')
+const { getCachingRequiresEntries, detectMisplacedKeyManagement } = require('./lib/config-normalizer')
 const { resolvePluginRoots } = require('./lib/plugin-roots')
 
 const LOG = cds.log("cds-caching");
+
+/**
+ * Parsed project package.json, or an empty object when unreadable.
+ * @returns {object}
+ */
+function readProjectPackage() {
+    try {
+        const pkgPath = path.join(cds.root, 'package.json')
+        if (!fs.existsSync(pkgPath)) return {}
+        return JSON.parse(fs.readFileSync(pkgPath, 'utf8'))
+    } catch {
+        return {}
+    }
+}
 
 // Auto-register plugin entity models based on service configuration.
 // See docs/feature-activation.md for reuse vs project-owned activation.
@@ -21,6 +35,9 @@ for (const root of pluginRoots) {
     if (!cds.env.roots.includes(root)) cds.env.roots.push(root)
 }
 for (const message of warnings) LOG.warn(message)
+
+const misplacedKeyManagement = detectMisplacedKeyManagement(cds.env, readProjectPackage())
+if (misplacedKeyManagement) LOG.warn(misplacedKeyManagement)
 
 cds.on('served', scanCachingAnnotations)
 

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -115,15 +115,19 @@ This also transitively loads the required database entities (`Caches`, `Metrics`
 
 ## Securing the Dashboard
 
-By default the `CachingApiService` is accessible without authentication. **Always restrict access in production** — the API can list cache entries and perform destructive operations (`clear`, `deleteEntry`, …).
+Since 2.1.0 `CachingApiService` requires an authenticated user by default, and the `/caching-dashboard` static route (when served via `metrics.reuse.dashboard`) is guarded the same way. Unauthenticated callers get `401`.
 
-On BTP, `cds add caching-dashboard` generates an `xs-app.json` with `authenticationType: "xsuaa"` for both the UI and `/odata/v4/caching-api/*`. Complement this with a CDS authorization on the service itself:
+**That default is a floor, not a production setting** — every logged-in user of your application satisfies `authenticated-user`, and this API can list cache entries and perform destructive operations (`clear`, `deleteEntry`, …). Restrict it to an administrative role:
 
 ```cds
-annotate plugin.cds_caching.CachingApiService with @requires: 'authenticated-user';
+annotate plugin.cds_caching.CachingApiService with @requires: 'CacheAdmin';
 ```
 
-For role-based access, use a dedicated scope (for example `'CacheAdmin'`) instead of `'authenticated-user'`. See the [Feature Activation Guide — BTP and MTX](feature-activation.md#sap-btp-single-tenant-or-shared-db) for the full production checklist.
+Your annotation is a downstream layer, so it replaces the plugin default. See [Security](security.md) for the full checklist.
+
+On BTP, `cds add caching-dashboard` additionally generates an `xs-app.json` with `authenticationType: "xsuaa"` for both the UI and `/odata/v4/caching-api/*`.
+
+> **Local development:** with CAP's mocked authentication the dashboard now prompts for credentials. Define users under `cds.requires.auth` to log in during `cds watch`.
 
 > **Important:** annotate the fully-qualified name (`plugin.cds_caching.CachingApiService`) and do **not** repeat the `using {plugin.cds_caching.CachingApiService} from 'cds-caching/index.cds';` import. Importing the same service name twice in the same model causes a `Duplicate definition of CachingApiService` error at startup (see [issue #24](https://github.com/mikezaschka/cds-caching/issues/24)). The fully-qualified `annotate` needs no `using` and works in any `.cds` file under `srv/`.
 

--- a/docs/feature-activation.md
+++ b/docs/feature-activation.md
@@ -113,11 +113,13 @@ The plugin deduplicates automatic loading:
 
 ### Securing the API
 
+The service ships with `@requires: 'authenticated-user'`. Tighten it to an administrative role for production:
+
 ```cds
-annotate plugin.cds_caching.CachingApiService with @requires: 'authenticated-user';
+annotate plugin.cds_caching.CachingApiService with @requires: 'CacheAdmin';
 ```
 
-Use the fully-qualified name — do not repeat the `using` import.
+Use the fully-qualified name — do not repeat the `using` import. See [Security](security.md).
 
 ## Recommended setups
 

--- a/docs/key-management.md
+++ b/docs/key-management.md
@@ -99,6 +99,8 @@ The default key generation behavior is configured **per cache service**, inside 
 
 > **Security:** with `isUserAware: false`, a single cached entry is shared by every user. If the underlying data is filtered per user — via `@restrict`, a `where` clause on `cds.context.user`, or row-level rules — set `isUserAware: true`, otherwise one user's rows can be served to another. See [Security](security.md#cache-key-isolation).
 
+> **Note:** these flags add context to the key, they do not make the key reflect the query that actually ran. On requests carrying an OData query string the hash comes from the URL, so a `where` clause added by `@restrict` or a handler does not contribute to it. Filtering driven by something other than the user id — a request header under a shared technical user, for example — therefore still shares one entry. See [what the awareness flags do not cover](security.md#what-the-awareness-flags-do-not-cover).
+
 ### When to Use Context Awareness
 
 #### User Awareness (`isUserAware: true`)

--- a/docs/key-management.md
+++ b/docs/key-management.md
@@ -69,26 +69,35 @@ return result
 
 ### Package.json Configuration
 
-The default key generation behavior can be configured globally in your `package.json`:
+The default key generation behavior is configured **per cache service**, inside its `cds.requires` block in `package.json`:
 
 ```json
 {
-  "cds-caching": {
-    "keyManagement": {
-      "isUserAware": true,
-      "isTenantAware": true,
-      "isLocaleAware": false
+  "cds": {
+    "requires": {
+      "caching": {
+        "impl": "cds-caching",
+        "keyManagement": {
+          "isUserAware": true,
+          "isTenantAware": true,
+          "isLocaleAware": false
+        }
+      }
     }
   }
 }
 ```
 
+> **Note:** `keyManagement` must sit inside the individual cache configuration. A top-level `"cds-caching"` block — which releases up to 2.0.2 documented here by mistake — is **not** read, and cache keys silently stay context-free. Since 2.1.0 the plugin logs a warning if it finds one.
+
 **Default behavior** (if not configured):
 - `isUserAware`: `false` - Include the logged in user in cache keys
-- `isTenantAware`: `false` - Include tenant context in cache keys  
+- `isTenantAware`: follows multitenancy — `true` in MTX mode, otherwise `false`
 - `isLocaleAware`: `false` - Include locale context in cache keys
 
-**Important**: This configuration applies to **all cache operations**, not just read-through functions.
+**Important**: This configuration applies to **all cache operations** of that cache service, not just read-through functions.
+
+> **Security:** with `isUserAware: false`, a single cached entry is shared by every user. If the underlying data is filtered per user — via `@restrict`, a `where` clause on `cds.context.user`, or row-level rules — set `isUserAware: true`, otherwise one user's rows can be served to another. See [Security](security.md#cache-key-isolation).
 
 ### When to Use Context Awareness
 
@@ -346,11 +355,16 @@ await cachedOperation("1000001")
 
 ```json
 {
-  "cds-caching": {
-    "keyManagement": {
-      "isUserAware": true,      // Enable for user-specific data
-      "isTenantAware": true,    // Enable for multi-tenant apps
-      "isLocaleAware": false    // Disable if not needed
+  "cds": {
+    "requires": {
+      "caching": {
+        "impl": "cds-caching",
+        "keyManagement": {
+          "isUserAware": true,
+          "isTenantAware": true,
+          "isLocaleAware": false
+        }
+      }
     }
   }
 }

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -1,5 +1,76 @@
 # Migration Guide
 
+## Upgrading to 2.1
+
+Version 2.1 is a security-hardening release. It closes several unauthenticated access paths and changes runtime behavior, so read this before upgrading. See [Security](security.md) for the full picture.
+
+### Breaking: the management API now requires authentication
+
+`CachingApiService` ships with `@requires: 'authenticated-user'`. Previously it was reachable without credentials unless you added the annotation yourself.
+
+- **If you already annotated the service**, nothing changes — your annotation still takes precedence.
+- **If you did not**, callers now receive `401`. Any script or monitoring job hitting `/odata/v4/caching-api/*` must authenticate.
+- **In local development** with CAP's mocked authentication, `cds watch` now prompts for credentials on the API and the dashboard. Define users under `cds.requires.auth`.
+
+`authenticated-user` is a floor, not a production setting. Tighten it:
+
+```cds
+annotate plugin.cds_caching.CachingApiService with @requires: 'CacheAdmin';
+```
+
+### Breaking: `Caches` is read-only over OData
+
+`POST`, `PATCH`, and `DELETE` on `Caches` are rejected. Use the `setMetricsEnabled` and `setKeyMetricsEnabled` actions to toggle metrics. Direct writes were never the intended path and allowed tampering with stored cache configuration.
+
+### Breaking: the cache key is no longer echoed in responses
+
+`x-sap-cap-cache-key` is now opt-in. If you relied on it — for example in tests that read a key from the response — enable it explicitly for that cache:
+
+```json
+{
+  "cds": {
+    "requires": {
+      "caching": {
+        "impl": "cds-caching",
+        "debugHeaders": true
+      }
+    }
+  }
+}
+```
+
+Keep it off in production: the key is enough to address a specific cached entry from outside. The `x-sap-cap-cache` hit/miss header is unchanged.
+
+### Behavior changes that need no action
+
+- Cache names in API routes are validated against your configured caches; unknown names return `404`.
+- `getEntries` is paginated: 100 entries by default, 1000 maximum. It accepts `top` and `skip`.
+- `setEntry` rejects values above 1 MB.
+- Credential-bearing headers (`Authorization`, `Cookie`, and similar) are redacted before being written to `KeyMetrics`, and long free-text fields are truncated. Tune with `metrics.maxMetricFieldLength`.
+- The `/caching-dashboard` static route (when using `metrics.reuse.dashboard`) requires an authenticated user.
+- `cds build` no longer logs the full `cds.env.requires` object, which included credentials.
+
+### Check your key management configuration
+
+Releases up to 2.0.2 documented `keyManagement` as a **top-level** `"cds-caching"` block in `package.json`. The runtime never read that, so those projects have context-free cache keys today despite looking configured. The plugin now warns at startup when it finds such a block.
+
+Move it into the cache's own `cds.requires` entry:
+
+```json
+{
+  "cds": {
+    "requires": {
+      "caching": {
+        "impl": "cds-caching",
+        "keyManagement": { "isUserAware": true }
+      }
+    }
+  }
+}
+```
+
+**If your cached data is filtered per user** — `@restrict`, a `where` clause on `cds.context.user`, or any row-level rule — set `isUserAware: true`. Without it, one cached entry is shared across users. See [Cache key isolation](security.md#cache-key-isolation).
+
 ## Upgrading to 2.0
 
 Version 2.0 aligns monitoring configuration around a single `metrics` object and CAP-style **reuse** flags ([reuse & compose](https://cap.cloud.sap/docs/guides/integration/reuse-and-compose#reuse-uis)). Cache runtime behavior, store types, and programmatic APIs are unchanged.
@@ -98,7 +169,7 @@ Migrate at your convenience before v3.0.
 2. Run `cds deploy` if you use database-backed metrics or `store: cds`.
 3. Remove redundant `using … index.cds` if you enable `metrics.reuse.api`.
 4. Remove `metrics.reuse.dashboard` if you use `cds add caching-metrics` (or the deprecated `cds add caching-dashboard`).
-5. Secure production APIs: `annotate plugin.cds_caching.CachingApiService with @requires: 'authenticated-user';`
+5. Secure production APIs: the service now defaults to `authenticated-user`; tighten it with `annotate plugin.cds_caching.CachingApiService with @requires: 'CacheAdmin';`
 
 ### No changes needed
 

--- a/docs/odata-api.md
+++ b/docs/odata-api.md
@@ -437,3 +437,45 @@ Retrieves key-level performance metrics with optional filtering.
 GET /odata/v4/caching-api/KeyMetrics?$filter=cache eq 'caching'&$orderby=hits desc
 ```
 
+## Security Considerations
+
+See [Security](security.md) for the full picture. The points specific to this API:
+
+### The API is authenticated by default
+
+Since 2.1.0 the service ships with `@requires: 'authenticated-user'`. Any caller without a valid session receives `401`. Restrict it further with a dedicated role in your own model:
+
+```cds
+annotate plugin.cds_caching.CachingApiService with @requires: 'CacheAdmin';
+```
+
+Because your model is a downstream layer, your annotation takes precedence over the plugin default. Treat this API as administrative — it can read every cached value and flush caches, so `authenticated-user` alone is usually too broad for production.
+
+### `Caches` is read-only over OData
+
+`Caches` rows carry each cache's `config`, `metricsEnabled`, and `keyMetricsEnabled`. The entity is annotated `@readonly`, so `POST`, `PATCH`, and `DELETE` are rejected — use `setMetricsEnabled` and `setKeyMetricsEnabled` instead. This prevents a caller from silently switching metrics collection on or rewriting a cache's stored configuration.
+
+### Cache names are validated against configuration
+
+The cache name in the entity key is checked against the set of services configured with `impl: 'cds-caching'` before any connection is made. Unknown names return `404` rather than being passed to `cds.connect.to()`.
+
+### `getEntries` is paginated
+
+`getEntries` accepts `top` and `skip`. It returns 100 entries by default and never more than 1000 per call, regardless of the requested `top`:
+
+```http
+GET /odata/v4/caching-api/Caches('caching')/getEntries(top=50,skip=100)
+```
+
+### `setEntry` values are size-limited
+
+Values above 1 MB are rejected with `400`.
+
+### Metrics data can be sensitive
+
+With `keyMetricsEnabled`, `KeyMetrics` rows retain per-key context: the serialized query (including filter values), the target entity, and the requesting user and tenant. Credential-bearing headers (`Authorization`, `Cookie`, `X-API-Key`, and similar) are redacted before persisting, and long fields are truncated. Even so, treat `KeyMetrics` as sensitive operational data and restrict read access accordingly. Key metrics are off by default.
+
+### Rate limiting is not provided
+
+CAP ships no rate limiter and neither does this plugin. If the API is reachable from outside your landscape, apply limits at the approuter, API gateway, or ingress layer.
+

--- a/docs/programmatic-api.md
+++ b/docs/programmatic-api.md
@@ -623,23 +623,30 @@ The cds-caching library provides automatic key generation for all cache operatio
 
 ### Global Configuration
 
-Configure key management behavior in your `package.json`:
+Configure key management behavior per cache service, inside its `cds.requires` block:
 
 ```json
 {
-  "cds-caching": {
-    "keyManagement": {
-      "isUserAware": true,
-      "isTenantAware": true,
-      "isLocaleAware": false
+  "cds": {
+    "requires": {
+      "caching": {
+        "impl": "cds-caching",
+        "keyManagement": {
+          "isUserAware": true,
+          "isTenantAware": true,
+          "isLocaleAware": false
+        }
+      }
     }
   }
 }
 ```
 
+> **Note:** a top-level `"cds-caching"` block is not read — see [Key Management](key-management.md#global-configuration).
+
 **Default behavior** (if not configured):
 - `isUserAware`: `false` - Include the logged in user in cache keys
-- `isTenantAware`: `false` - Include tenant context in cache keys  
+- `isTenantAware`: follows multitenancy — `true` in MTX mode, otherwise `false`
 - `isLocaleAware`: `false` - Include locale context in cache keys
 
 ### Key Template Variables

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,153 @@
+# Security
+
+This document covers the security-relevant behavior of `cds-caching`: what is protected by default, what you must configure yourself, and the decisions worth reviewing before going to production.
+
+To report a vulnerability, see [SECURITY.md](../SECURITY.md).
+
+## Table of Contents
+
+1. [Production checklist](#production-checklist)
+2. [Management API and dashboard](#management-api-and-dashboard)
+3. [Cache key isolation](#cache-key-isolation)
+4. [Debug response headers](#debug-response-headers)
+5. [Metrics data](#metrics-data)
+6. [Data at rest](#data-at-rest)
+7. [Resource limits](#resource-limits)
+8. [Content Security Policy](#content-security-policy)
+
+## Production checklist
+
+- Restrict `CachingApiService` to an administrative role rather than leaving it at the default `authenticated-user`.
+- Set `keyManagement.isUserAware: true` for any cache holding user-filtered data.
+- Leave `debugHeaders` off.
+- Decide whether `keyMetricsEnabled` is acceptable for your data, and who may read `KeyMetrics`.
+- Apply rate limits in front of the management API if it is externally reachable.
+- Confirm your store's transport and at-rest encryption (Redis TLS, HANA, Postgres).
+
+## Management API and dashboard
+
+### Default authorization
+
+`CachingApiService` is annotated `@requires: 'authenticated-user'`. Unauthenticated callers receive `401`.
+
+This default exists because the API can enumerate and delete cached values and flush entire caches. It is deliberately the *least* restrictive safe setting so that adding it does not break existing deployments — it is usually **not** sufficient for production, since every logged-in user of your application satisfies it.
+
+Narrow it to a dedicated role in your own model:
+
+```cds
+using {plugin.cds_caching.CachingApiService} from 'cds-caching/index.cds';
+
+annotate plugin.cds_caching.CachingApiService with @requires: 'CacheAdmin';
+```
+
+Your model is a downstream annotation layer, so this replaces the plugin's default. To expose the API without authentication — only sensible for a strictly internal, network-isolated deployment — set `@requires: null`.
+
+### Local development
+
+With CAP's mocked authentication (the default outside production), the API and dashboard now require credentials. `cds watch` will prompt for a login. Define users in your `cds.requires.auth` block, or pass basic credentials from your HTTP client.
+
+### `Caches` is read-only over OData
+
+Cache configuration rows are exposed `@readonly`. Metrics flags are changed through the `setMetricsEnabled` and `setKeyMetricsEnabled` actions, which run through the plugin's own logic, rather than by writing to the entity.
+
+### Cache name validation
+
+The cache name in an API route is validated against the services configured with `impl: 'cds-caching'`. This stops a caller from using the route to reach an unrelated business service through `cds.connect.to()`.
+
+### Dashboard static assets
+
+When `metrics.reuse.dashboard` is enabled, the dashboard is served from `/caching-dashboard`. That route sits outside CAP's service adapters, so it is wrapped in CAP's own middleware chain plus an explicit authenticated-user check. Restricting the OData API alone would not have protected it, since it is not a CAP service.
+
+## Cache key isolation
+
+**This is the most important setting to review.**
+
+Cache keys are built from a template. By default the template is `{hash}` — derived from the request or query alone, with no user context. Every user shares one cached entry per distinct request.
+
+That is correct for public, unfiltered data. It is **wrong**, and a cross-user data leak, when the cached data is filtered per user, whether through `@restrict`, a `where` clause referencing `cds.context.user`, or any row-level rule. Two users issuing the same request would then receive the same cached rows.
+
+Enable user-aware keys per cache service:
+
+```json
+{
+  "cds": {
+    "requires": {
+      "caching": {
+        "impl": "cds-caching",
+        "keyManagement": {
+          "isUserAware": true,
+          "isTenantAware": true
+        }
+      }
+    }
+  }
+}
+```
+
+`keyManagement` must sit inside the individual cache configuration. A top-level `"cds-caching"` block is ignored; the plugin warns at startup if it finds one. See [Key Management](key-management.md).
+
+`isTenantAware` defaults to `true` when multitenancy is detected, so tenants are separated by default in MTX mode.
+
+You can also set the template per operation, which overrides the global setting:
+
+```javascript
+const { result } = await cache.rt.run(query, db, { key: '{tenant}:{user}:{hash}' })
+```
+
+## Debug response headers
+
+Read-through HTTP responses can include the full cache key in `x-sap-cap-cache-key`. Knowing a key makes it possible to address a specific cached entry directly, so this is **off by default** and should stay off in production. Enable it only for local debugging:
+
+```json
+{
+  "cds": {
+    "requires": {
+      "caching": {
+        "impl": "cds-caching",
+        "debugHeaders": true
+      }
+    }
+  }
+}
+```
+
+The `x-sap-cap-cache` hit/miss header is always sent; it carries no key material.
+
+## Metrics data
+
+Aggregate `Metrics` rows hold counters and latencies only.
+
+`KeyMetrics` rows are richer and only collected when `keyMetricsEnabled` is on (off by default). Each row can retain:
+
+- the serialized query, **including filter values**
+- the target entity and service
+- the requesting user id, tenant, and locale
+- request path, method, and parameters
+
+Credential-bearing headers are redacted before anything is persisted: `Authorization`, `Proxy-Authorization`, `Cookie`, `Set-Cookie`, `X-API-Key`, `ApiKey`, `X-CSRF-Token`, `X-XSRF-Token`, and `sap-passport`. Long free-text fields are truncated (8192 characters by default, configurable via `metrics.maxMetricFieldLength`).
+
+Two consequences worth planning for: `KeyMetrics` may fall under your data-protection obligations because it stores user ids and query filter values, and anyone who can read the API can read it. Restrict the API accordingly, and leave key metrics off unless you are actively investigating.
+
+## Data at rest
+
+Cached values are stored **unencrypted** in whichever store you configure, for every store type including `store: 'cds'`. A cached value is a copy of data your application already holds, so the cache inherits the sensitivity of its source.
+
+Consequences:
+
+- With `store: 'cds'`, values are readable in the `CacheStore` table by anyone with database access, at the same level of protection as your other application tables.
+- With `store: 'redis'`, values are readable by anyone with Redis access. Use TLS and credentials, and do not share the instance across trust boundaries.
+- Cached values can outlive their source rows until their TTL expires or they are invalidated. Deleting a record does not by itself remove it from the cache — use `@cache.invalidateOnWrite` or tag-based invalidation.
+
+Avoid caching highly sensitive data, use a short TTL where you must, and prefer a store whose at-rest encryption you control.
+
+## Resource limits
+
+- `getEntries` returns 100 entries by default and at most 1000 per call.
+- `setEntry` rejects values larger than 1 MB.
+- `metrics.maxKeyMetrics` bounds how many distinct keys are tracked in memory.
+
+No rate limiting is applied to the management API — CAP does not provide one. Enforce limits at the approuter, API gateway, or ingress if the API is reachable from outside your landscape.
+
+## Content Security Policy
+
+The dashboard loads the UI5 runtime. If you serve it through `metrics.reuse.dashboard` or the generated `cds add caching-dashboard` app and your CSP restricts script sources, allow the UI5 host you are using — for example `script-src https://ui5.sap.com` when bootstrapping from the SAP CDN.

--- a/docs/security.md
+++ b/docs/security.md
@@ -9,6 +9,7 @@ To report a vulnerability, see [SECURITY.md](../SECURITY.md).
 1. [Production checklist](#production-checklist)
 2. [Management API and dashboard](#management-api-and-dashboard)
 3. [Cache key isolation](#cache-key-isolation)
+   - [What the awareness flags do not cover](#what-the-awareness-flags-do-not-cover)
 4. [Debug response headers](#debug-response-headers)
 5. [Metrics data](#metrics-data)
 6. [Data at rest](#data-at-rest)
@@ -18,7 +19,7 @@ To report a vulnerability, see [SECURITY.md](../SECURITY.md).
 ## Production checklist
 
 - Restrict `CachingApiService` to an administrative role rather than leaving it at the default `authenticated-user`.
-- Set `keyManagement.isUserAware: true` for any cache holding user-filtered data.
+- Set `keyManagement.isUserAware: true` for any cache holding user-filtered data, and `isLocaleAware: true` for translated content. Check [what the flags do not cover](#what-the-awareness-flags-do-not-cover) if your filtering is not derived from the user id.
 - Leave `debugHeaders` off.
 - Decide whether `keyMetricsEnabled` is acceptable for your data, and who may read `KeyMetrics`.
 - Apply rate limits in front of the management API if it is externally reachable.
@@ -87,6 +88,20 @@ Enable user-aware keys per cache service:
 `keyManagement` must sit inside the individual cache configuration. A top-level `"cds-caching"` block is ignored; the plugin warns at startup if it finds one. See [Key Management](key-management.md).
 
 `isTenantAware` defaults to `true` when multitenancy is detected, so tenants are separated by default in MTX mode.
+
+### What the awareness flags do not cover
+
+These flags add context to the key; they do not make the key reflect the query that actually ran. For a request carrying an OData query string, the hash is derived from the URL and request metadata, and the CQN does not contribute — which is where a `where` clause added by `@restrict` or by a custom handler lives. All isolation therefore comes from the template dimensions you enabled, so review whether they cover every way your data varies.
+
+Two cases they do not cover:
+
+- **Filtering not derived from the user id.** When a single technical user issues the request — an integration user, a background job, or a service called with client credentials instead of principal propagation — and a handler narrows the query from a request header or another non-identity source, `isUserAware` gives you nothing: the user component is constant while the data is not. Pass a template that includes the discriminating value, or keep such reads out of the cache.
+
+```javascript
+const { result } = await cache.rt.run(query, db, { key: `${region}:{user}:{hash}` })
+```
+
+- **Locale.** `isLocaleAware` defaults to `false`, so responses in different languages share one entry. Enable it for any cache holding translated texts.
 
 You can also set the template per operation, which overrides the global setting:
 

--- a/index.cds
+++ b/index.cds
@@ -2,9 +2,22 @@ using from './db/statistics';
 
 context plugin.cds_caching {
 
-    @impl: 'cds-caching/srv/caching-api-service'
+    /**
+     * Management API for cache entries and metrics.
+     *
+     * Guarded with `authenticated-user` by default, because these operations can
+     * read and flush cache contents. Override in your own model to require a
+     * dedicated role instead:
+     *
+     *   annotate plugin.cds_caching.CachingApiService with @requires: 'CacheAdmin';
+     */
+    @impl    : 'cds-caching/srv/caching-api-service'
+    @requires: 'authenticated-user'
     service CachingApiService {
 
+        // Writes go through the bound actions below, never through CRUD, so that
+        // config rows (metricsEnabled, config) cannot be tampered with directly.
+        @readonly
         entity Caches     as projection on plugin.cds_caching.Caches
             actions {
 

--- a/index.cds
+++ b/index.cds
@@ -21,7 +21,7 @@ context plugin.cds_caching {
         entity Caches     as projection on plugin.cds_caching.Caches
             actions {
 
-                function getEntries()                                          returns array of {
+                function getEntries(top : Integer, skip : Integer)             returns array of {
                     entryKey  : String;
                     value     : String;
                     timestamp : DateTime;

--- a/lib/CachingService.js
+++ b/lib/CachingService.js
@@ -23,6 +23,9 @@ class CachingService extends cds.Service {
             credentials: {},
             namespace: null,
             throwOnErrors: false,
+            // When enabled, read-through HTTP responses carry the full cache key in
+            // `x-sap-cap-cache-key`. Useful for debugging, unsafe in production.
+            debugHeaders: false,
             // When enabled, basic cache operations (`get`, `set`, `delete`, ...)
             // will be executed in a dedicated cache transaction (`cache.tx()`),
             // isolating them from the caller's request transaction (e.g. concurrent BEFORE handlers).

--- a/lib/config-normalizer.js
+++ b/lib/config-normalizer.js
@@ -109,6 +109,7 @@ function getStatisticsHandlerOptions(metrics) {
     if (metrics.persistenceInterval != null) opts.persistenceInterval = metrics.persistenceInterval
     if (metrics.maxLatencies != null) opts.maxLatencies = metrics.maxLatencies
     if (metrics.maxKeyMetrics != null) opts.maxKeyMetrics = metrics.maxKeyMetrics
+    if (metrics.maxMetricFieldLength != null) opts.maxMetricFieldLength = metrics.maxMetricFieldLength
     if (metrics.enabled === true) opts.metricsEnabled = true
     if (metrics.keyMetricsEnabled === true) opts.keyMetricsEnabled = true
     return opts

--- a/lib/config-normalizer.js
+++ b/lib/config-normalizer.js
@@ -123,10 +123,37 @@ function isMetricsConfigured(normalized) {
     return normalized.metrics != null
 }
 
+/**
+ * Detect a `keyManagement` block placed outside `cds.requires.<cache>`.
+ *
+ * Releases up to 2.0.2 documented this as a top-level `"cds-caching"` key, which
+ * the runtime never read — so keys silently stayed context-free even though the
+ * project looked configured for user-aware caching. Warn loudly instead.
+ *
+ * @param {object} [env={}] - cds.env
+ * @param {object} [projectPackage={}] - Parsed project package.json
+ * @returns {string|null} Warning message, or null when nothing is misplaced
+ */
+function detectMisplacedKeyManagement(env = {}, projectPackage = {}) {
+    const misplaced =
+        env['cds-caching']?.keyManagement ??
+        projectPackage['cds-caching']?.keyManagement
+
+    if (!misplaced) return null
+
+    return warnOnce(
+        'misplaced-keyManagement',
+        'cds-caching: a "cds-caching.keyManagement" block was found outside "cds.requires", where it is ignored. ' +
+        'Cache keys are therefore NOT user/tenant/locale aware. Move it into the individual cache config, e.g. ' +
+        '{"cds":{"requires":{"caching":{"keyManagement":{"isUserAware":true}}}}}. See docs/key-management.md.'
+    )
+}
+
 module.exports = {
     normalizeCachingConfig,
     getCachingRequiresEntries,
     getStatisticsHandlerOptions,
     isMetricsConfigured,
+    detectMisplacedKeyManagement,
     resetDeprecationWarnings,
 }

--- a/lib/dashboard-guard.js
+++ b/lib/dashboard-guard.js
@@ -1,0 +1,32 @@
+const cds = require('@sap/cds')
+
+/**
+ * Express guard requiring an authenticated user.
+ *
+ * The dashboard is served as static files outside CAP's service adapters, so it
+ * inherits no authorization from the model. Restricting `CachingApiService` alone
+ * would leave this route open.
+ *
+ * @param {object} req - Express request
+ * @param {object} res - Express response
+ * @param {Function} next - Downstream handler
+ */
+function requireAuthenticatedUser(req, res, next) {
+    const user = cds.context?.user
+    if (user?.is?.('authenticated-user')) return next()
+
+    res.status(401).set('WWW-Authenticate', 'Basic realm="cds-caching"').end()
+}
+
+/**
+ * CAP's own request middlewares (context, trace, auth, model), flattened and
+ * compacted so they can be spread into an `app.use()` call. These populate
+ * `cds.context.user`, which the guard above depends on.
+ *
+ * @returns {Function[]}
+ */
+function capRequestMiddlewares() {
+    return (cds.middlewares?.before ?? []).flat().filter(Boolean)
+}
+
+module.exports = { requireAuthenticatedUser, capRequestMiddlewares }

--- a/lib/operations/CapOperations.js
+++ b/lib/operations/CapOperations.js
@@ -1,5 +1,6 @@
 const TagResolver = require('../support/TagResolver');
 const telemetry = require('../support/Telemetry');
+const { redactHeaders } = require('../support/metricsSanitizer');
 /**
  * Manages CAP-specific cache operations
  */
@@ -140,7 +141,7 @@ class CapOperations {
                 subject: request.subject,
                 query: request.query,
                 event: request.event,
-                headers: request.headers,
+                headers: redactHeaders(request.headers),
             }),
             cacheOptions: JSON.stringify(requestOptions)
         };

--- a/lib/operations/CapOperations.js
+++ b/lib/operations/CapOperations.js
@@ -21,6 +21,16 @@ class CapOperations {
     }
 
     /**
+     * Whether the full cache key may be echoed back in the `x-sap-cap-cache-key`
+     * response header. Off unless opted in, because the key is enough to target a
+     * specific cached entry from outside.
+     * @returns {boolean}
+     */
+    debugHeadersEnabled() {
+        return this.runtimeConfigManager?.options?.debugHeaders === true;
+    }
+
+    /**
      * Safely execute cache operations with error handling
      * @param {Function} operation - The cache operation to execute
      * @param {string} operationName - Name of the operation for logging
@@ -284,7 +294,9 @@ class CapOperations {
                     req.cacheOptions = req.event ? this.extractFunctionCacheOptions(req, arguments[2]) : this.extractEntityCacheOptions(req, arguments[2]);
 
                     req.cacheKey = this.keyManager.createKey(req, {}, req.cacheOptions.key);
-                    req.res?.setHeader('x-sap-cap-cache-key', req.cacheKey);
+                    if (this.debugHeadersEnabled()) {
+                        req.res?.setHeader('x-sap-cap-cache-key', req.cacheKey);
+                    }
 
                     // Track cache operation timing
                     const startTime = process.hrtime();

--- a/lib/support/CacheStatisticsHandler.js
+++ b/lib/support/CacheStatisticsHandler.js
@@ -4,6 +4,7 @@ const StatisticsPersistenceManager = require('./StatisticsPersistenceManager');
 const telemetry = require('./Telemetry');
 const { query } = require('@sap/cds/lib/env/defaults');
 const { isPluginModelAvailable } = require('../util');
+const { truncateMetadataFields, MAX_FIELD_LENGTH } = require('./metricsSanitizer');
 
 /**
  * Class to handle all things caching statistics.
@@ -17,6 +18,7 @@ class CacheStatisticsHandler {
             persistenceInterval: 10 * 1000, // 10 seconds 
             maxLatencies: 2000,
             maxKeyMetrics: 1000, // Track top accessed keys
+            maxMetricFieldLength: MAX_FIELD_LENGTH, // Cap per free-text KeyMetrics field
             keyMetricsEnabled: false,
             metricsEnabled: false, // Main metrics enabled flag
             ...options
@@ -417,6 +419,10 @@ class CacheStatisticsHandler {
             this.log.warn('recordKeyAccess called with null/undefined key');
             return;
         }
+
+        // Single choke point for every operation path, so no caller can persist
+        // an unbounded serialized request into KeyMetrics.
+        metadata = truncateMetadataFields(metadata, this.options.maxMetricFieldLength);
 
         if (!this.stats.current.keyAccess.has(key)) {
             this.log.debug(`Creating new key stats for: ${key}`);

--- a/lib/support/metricsSanitizer.js
+++ b/lib/support/metricsSanitizer.js
@@ -1,0 +1,84 @@
+/**
+ * Sanitizing helpers for data that gets persisted into the KeyMetrics entity.
+ *
+ * KeyMetrics rows are long-lived and readable through the management API, so
+ * credentials must never reach them and single fields must not grow unbounded.
+ */
+
+/** Header names whose values are credentials or session material. */
+const SENSITIVE_HEADERS = new Set([
+    'authorization',
+    'proxy-authorization',
+    'cookie',
+    'set-cookie',
+    'x-api-key',
+    'apikey',
+    'x-csrf-token',
+    'x-xsrf-token',
+    'sap-passport',
+]);
+
+const REDACTED = '[redacted]';
+
+/** Default cap for free-text metric fields (metadata, query, subject, context). */
+const MAX_FIELD_LENGTH = 8192;
+
+/** Fields that carry serialized request/query detail and can grow without bound. */
+const TRUNCATED_FIELDS = ['metadata', 'query', 'subject', 'context', 'cacheOptions'];
+
+/**
+ * Copy headers with credential-bearing values replaced.
+ * @param {object} headers - Raw header map (case-insensitive keys)
+ * @returns {object|undefined} Redacted copy, or undefined if there was nothing to copy
+ */
+function redactHeaders(headers) {
+    if (!headers || typeof headers !== 'object') return undefined;
+
+    const safe = {};
+    for (const [name, value] of Object.entries(headers)) {
+        safe[name] = SENSITIVE_HEADERS.has(name.toLowerCase()) ? REDACTED : value;
+    }
+    return safe;
+}
+
+/**
+ * Truncate a single field to `max` characters, marking where it was cut.
+ * @param {any} value - Field value; non-strings are returned unchanged
+ * @param {number} [max=MAX_FIELD_LENGTH] - Maximum length to keep
+ * @returns {any}
+ */
+function truncateField(value, max = MAX_FIELD_LENGTH) {
+    if (typeof value !== 'string' || value.length <= max) return value;
+    return `${value.slice(0, max)}…[truncated ${value.length - max} chars]`;
+}
+
+/**
+ * Bound the free-text fields of a key-metrics metadata object.
+ * Returns the input unchanged when nothing needs truncating, so the common
+ * path allocates nothing.
+ * @param {object} metadata - Metadata as assembled by the operation layers
+ * @param {number} [max=MAX_FIELD_LENGTH] - Maximum length per field
+ * @returns {object}
+ */
+function truncateMetadataFields(metadata, max = MAX_FIELD_LENGTH) {
+    if (!metadata || typeof metadata !== 'object') return metadata;
+
+    let copy = null;
+    for (const field of TRUNCATED_FIELDS) {
+        const value = metadata[field];
+        if (typeof value === 'string' && value.length > max) {
+            copy ??= { ...metadata };
+            copy[field] = truncateField(value, max);
+        }
+    }
+    return copy ?? metadata;
+}
+
+module.exports = {
+    SENSITIVE_HEADERS,
+    REDACTED,
+    MAX_FIELD_LENGTH,
+    redactHeaders,
+    truncateField,
+    truncateMetadataFields,
+};

--- a/srv/caching-api-service.js
+++ b/srv/caching-api-service.js
@@ -4,6 +4,13 @@ const { isPluginModelAvailable } = require('../lib/util')
 
 const DEFAULT_TENANT = '_default';
 
+/** Upper bound for `getEntries`, regardless of the requested `top`. */
+const MAX_ENTRIES_PER_PAGE = 1000;
+const DEFAULT_ENTRIES_PER_PAGE = 100;
+
+/** Upper bound for a single `setEntry` value, in bytes. */
+const MAX_ENTRY_VALUE_BYTES = 1024 * 1024;
+
 class CachingApiService extends cds.ApplicationService {
     log = cds.log('cds-caching');
 
@@ -50,15 +57,26 @@ class CachingApiService extends cds.ApplicationService {
         // Handle getCacheEntries function
         this.on('getEntries', async (req) => {
             const cacheService = await this._connectToCache(req);
+            const { top, skip } = req.data;
+
+            // Bounded on purpose: an unbounded iteration would pull the whole
+            // cache into memory and can be used to exhaust the server.
+            const requested = Number.isInteger(top) && top > 0 ? top : DEFAULT_ENTRIES_PER_PAGE;
+            const limit = Math.min(requested, MAX_ENTRIES_PER_PAGE);
+            const offset = Number.isInteger(skip) && skip > 0 ? skip : 0;
+
             try {
                 const entries = [];
+                let seen = 0;
                 for await (const [key, value] of cacheService.iterator()) {
+                    if (seen++ < offset) continue;
                     entries.push({
                         entryKey: key,
                         value: JSON.stringify(value.value),
                         timestamp: value.timestamp,
                         tags: value.tags,
                     });
+                    if (entries.length >= limit) break;
                 }
                 return entries;
             } catch (error) {
@@ -81,6 +99,12 @@ class CachingApiService extends cds.ApplicationService {
         this.on('setEntry', async (req) => {
             const { key, value, ttl } = req.data;
             const cacheService = await this._connectToCache(req);
+
+            const size = Buffer.byteLength(String(value ?? ''), 'utf8');
+            if (size > MAX_ENTRY_VALUE_BYTES) {
+                return req.reject(400, `Value exceeds the maximum of ${MAX_ENTRY_VALUE_BYTES} bytes (got ${size})`);
+            }
+
             await cacheService.set(key, value, { ttl: ttl });
             req.info(`Cache entry set successfully: ${key}`);
             return true;

--- a/srv/caching-api-service.js
+++ b/srv/caching-api-service.js
@@ -20,8 +20,8 @@ class CachingApiService extends cds.ApplicationService {
         // Handle setMetricsEnabled action
         this.on('setMetricsEnabled', async (req) => {
             const { enabled } = req.data
-            const cache = req.params[0].name;
-            const cacheService = await cds.connect.to(cache);
+            const cacheService = await this._connectToCache(req);
+            const cache = this._cacheName(req);
             try {
                 await cacheService.setMetricsEnabled(enabled)
                 req.info(`Metrics ${enabled ? 'enabled' : 'disabled'} for cache ${cache}`);
@@ -35,8 +35,8 @@ class CachingApiService extends cds.ApplicationService {
         // Handle setKeyMetricsEnabled action
         this.on('setKeyMetricsEnabled', async (req) => {
             const { enabled } = req.data
-            const cache = req.params[0].name;
-            const cacheService = await cds.connect.to(cache);
+            const cacheService = await this._connectToCache(req);
+            const cache = this._cacheName(req);
             try {
                 await cacheService.setKeyMetricsEnabled(enabled)
                 req.info(`Key metrics ${enabled ? 'enabled' : 'disabled'} for cache ${cache}`);
@@ -49,9 +49,8 @@ class CachingApiService extends cds.ApplicationService {
 
         // Handle getCacheEntries function
         this.on('getEntries', async (req) => {
-            const cache = req.params[0].name;
+            const cacheService = await this._connectToCache(req);
             try {
-                const cacheService = await cds.connect.to(cache);
                 const entries = [];
                 for await (const [key, value] of cacheService.iterator()) {
                     entries.push({
@@ -71,8 +70,7 @@ class CachingApiService extends cds.ApplicationService {
         // Handle getCacheEntry function
         this.on('getEntry', async (req) => {
             const { key } = req.data;
-            const cache = req.params[0].name;
-            const cacheService = await cds.connect.to(cache);
+            const cacheService = await this._connectToCache(req);
             const value = await cacheService.get(key);
             return {
                 value: value,
@@ -82,8 +80,7 @@ class CachingApiService extends cds.ApplicationService {
         // Handle setCacheEntry action
         this.on('setEntry', async (req) => {
             const { key, value, ttl } = req.data;
-            const cache = req.params[0].name;
-            const cacheService = await cds.connect.to(cache);
+            const cacheService = await this._connectToCache(req);
             await cacheService.set(key, value, { ttl: ttl });
             req.info(`Cache entry set successfully: ${key}`);
             return true;
@@ -92,8 +89,7 @@ class CachingApiService extends cds.ApplicationService {
         // Handle deleteCacheEntry action
         this.on('deleteEntry', async (req) => {
             const { key } = req.data;
-            const cache = req.params[0].name;
-            const cacheService = await cds.connect.to(cache);
+            const cacheService = await this._connectToCache(req);
             await cacheService.delete(key);
             req.info(`Cache entry deleted successfully: ${key}`);
             return true;
@@ -101,8 +97,8 @@ class CachingApiService extends cds.ApplicationService {
 
         // Handle clearCache action
         this.on('clear', async (req) => {
-            const cache = req.params[0].name;
-            const cacheService = await cds.connect.to(cache);
+            const cacheService = await this._connectToCache(req);
+            const cache = this._cacheName(req);
             await cacheService.clear();
             req.info(`Cache cleared successfully: ${cache}`);
             return true;
@@ -110,8 +106,8 @@ class CachingApiService extends cds.ApplicationService {
 
         // Handle clearKeyMetrics action
         this.on('clearKeyMetrics', async (req) => {
-            const cache = req.params[0].name;
-            const cacheService = await cds.connect.to(cache);
+            const cacheService = await this._connectToCache(req);
+            const cache = this._cacheName(req);
             await cacheService.clearKeyMetrics();
             req.info(`Key metrics cleared successfully: ${cache}`);
             return true;
@@ -119,14 +115,54 @@ class CachingApiService extends cds.ApplicationService {
 
         // Handle clearMetrics action
         this.on('clearMetrics', async (req) => {
-            const cache = req.params[0].name;
-            const cacheService = await cds.connect.to(cache);
+            const cacheService = await this._connectToCache(req);
+            const cache = this._cacheName(req);
             await cacheService.clearMetrics();
             req.info(`Metrics cleared successfully: ${cache}`);
             return true;
         });
 
         await super.init()
+    }
+
+    /**
+     * Names of all configured cds-caching services. Used as an allow-list so a
+     * caller cannot coerce `cds.connect.to()` into connecting to an unrelated
+     * business service by passing its name as the cache key.
+     * @returns {Set<string>}
+     */
+    _allowedCaches() {
+        return new Set(
+            Object.entries(cds.env.requires || {})
+                .filter(([, config]) => config?.impl === 'cds-caching')
+                .map(([name]) => name)
+        );
+    }
+
+    /**
+     * Name of the cache addressed by the request key.
+     * @param {object} req - Inbound request carrying the Caches key
+     * @returns {string|undefined}
+     */
+    _cacheName(req) {
+        const param = req.params?.[0];
+        return typeof param === 'string' ? param : param?.name;
+    }
+
+    /**
+     * Resolve the cache addressed by the request key and connect to it.
+     * Rejects with 404 for anything that is not a configured cache.
+     * @param {object} req - Inbound request carrying the Caches key
+     * @returns {Promise<object>} The connected CachingService
+     */
+    async _connectToCache(req) {
+        const name = this._cacheName(req);
+
+        if (!name || !this._allowedCaches().has(name)) {
+            return req.reject(404, `Unknown cache: ${name}`);
+        }
+
+        return cds.connect.to(name);
     }
 
     /**

--- a/test/CachingApi.test.js
+++ b/test/CachingApi.test.js
@@ -1,11 +1,20 @@
 const cds = require('@sap/cds');
-const { GET, POST, expect } = cds.test().in(__dirname + '/app/')
+const test = cds.test().in(__dirname + '/app/')
+const { GET, POST, expect, axios } = test
 const { describeFromCds } = require('./helpers/cds-version')
+
+// CachingApiService requires an authenticated user, so every call in this suite
+// needs credentials. See the `auth` block in test/app/package.json.
+const ADMIN = { username: 'cacheadmin', password: 'cacheadmin' }
 
 describeFromCds(9, 'Caching API Service', () => {
 
     let cache;
     let appService;
+
+    before(() => {
+        axios.defaults.auth = ADMIN
+    })
 
     beforeEach(async () => {
         cache = await cds.connect.to("caching");

--- a/test/ConfigNormalizer.test.js
+++ b/test/ConfigNormalizer.test.js
@@ -1,6 +1,7 @@
 const {
     normalizeCachingConfig,
     getStatisticsHandlerOptions,
+    detectMisplacedKeyManagement,
     resetDeprecationWarnings,
 } = require('../lib/config-normalizer')
 
@@ -82,5 +83,47 @@ describe('getStatisticsHandlerOptions', () => {
             maxLatencies: 500,
             keyMetricsEnabled: true,
         })
+    })
+
+    it('passes through the metric field length cap', () => {
+        const opts = getStatisticsHandlerOptions({ maxMetricFieldLength: 512 })
+        expect(opts).toEqual({ maxMetricFieldLength: 512 })
+    })
+})
+
+describe('detectMisplacedKeyManagement', () => {
+
+    beforeEach(() => resetDeprecationWarnings())
+
+    it('returns null when keyManagement is correctly nested under requires', () => {
+        const env = { requires: { caching: { impl: 'cds-caching', keyManagement: { isUserAware: true } } } }
+        expect(detectMisplacedKeyManagement(env, {})).toBeNull()
+    })
+
+    it('warns about a top-level block in package.json', () => {
+        const pkg = { 'cds-caching': { keyManagement: { isUserAware: true } } }
+        const warning = detectMisplacedKeyManagement({}, pkg)
+        expect(warning).toMatch(/ignored/)
+        expect(warning).toMatch(/keyManagement/)
+    })
+
+    it('warns about a block reaching cds.env via .cdsrc.json', () => {
+        const env = { 'cds-caching': { keyManagement: { isTenantAware: true } } }
+        expect(detectMisplacedKeyManagement(env, {})).toMatch(/ignored/)
+    })
+
+    it('warns only once', () => {
+        const pkg = { 'cds-caching': { keyManagement: { isUserAware: true } } }
+        expect(detectMisplacedKeyManagement({}, pkg)).toMatch(/ignored/)
+        expect(detectMisplacedKeyManagement({}, pkg)).toBeNull()
+    })
+
+    it('ignores an unrelated cds-caching block without keyManagement', () => {
+        const pkg = { 'cds-caching': { somethingElse: true } }
+        expect(detectMisplacedKeyManagement({}, pkg)).toBeNull()
+    })
+
+    it('tolerates missing arguments', () => {
+        expect(detectMisplacedKeyManagement()).toBeNull()
     })
 })

--- a/test/Security.test.js
+++ b/test/Security.test.js
@@ -1,0 +1,353 @@
+const cds = require('@sap/cds');
+const test = cds.test().in(__dirname + '/app/')
+const { GET, POST, expect } = test
+const { describeFromCds } = require('./helpers/cds-version')
+const { redactHeaders, truncateField, truncateMetadataFields, REDACTED } = require('../lib/support/metricsSanitizer')
+
+const ADMIN = { auth: { username: 'cacheadmin', password: 'cacheadmin' } }
+const API = '/odata/v4/caching-api'
+
+/** An authenticated principal for programmatic dispatch. */
+const adminUser = () => new cds.User({ id: 'cacheadmin', roles: ['CacheAdmin'] })
+
+/** Status code of a failing request, or 'no error' when it unexpectedly succeeded. */
+async function statusOf(request) {
+    try {
+        await request
+        return 'no error'
+    } catch (error) {
+        return error.response?.status ?? error.message
+    }
+}
+
+describeFromCds(9, 'Security', () => {
+
+    describe('Management API authorization', () => {
+
+        it("rejects unauthenticated reads of Caches", async () => {
+            expect(await statusOf(GET(`${API}/Caches`))).to.equal(401)
+        })
+
+        it("rejects unauthenticated reads of Metrics and KeyMetrics", async () => {
+            expect(await statusOf(GET(`${API}/Metrics`))).to.equal(401)
+            expect(await statusOf(GET(`${API}/KeyMetrics`))).to.equal(401)
+        })
+
+        it("rejects unauthenticated cache entry enumeration", async () => {
+            expect(await statusOf(GET(`${API}/Caches('caching')/getEntries()`))).to.equal(401)
+        })
+
+        it("rejects unauthenticated flushing", async () => {
+            expect(await statusOf(POST(`${API}/Caches('caching')/clear`, {}))).to.equal(401)
+        })
+
+        it("rejects unauthenticated writes", async () => {
+            const call = POST(`${API}/Caches('caching')/setEntry`, { key: 'k', value: 'v', ttl: 0 })
+            expect(await statusOf(call)).to.equal(401)
+        })
+
+        it("allows an authenticated user", async () => {
+            const { data } = await GET(`${API}/Caches`, ADMIN)
+            expect(data.value).to.be.an('array')
+        })
+
+        it("is enforced for programmatic dispatch without a user", async () => {
+            const api = await cds.connect.to('plugin.cds_caching.CachingApiService')
+
+            // Guards against a code path that bypasses HTTP but still reaches the cache.
+            const call = api.send({
+                event: 'clear',
+                entity: 'Caches',
+                params: [{ name: 'caching' }],
+                data: {},
+            })
+
+            await expect(call).to.be.rejected
+        })
+
+        it("declares @requires on the service and @readonly on Caches", async () => {
+            const service = cds.model.definitions['plugin.cds_caching.CachingApiService']
+            expect(service['@requires']).to.equal('authenticated-user')
+
+            const caches = cds.model.definitions['plugin.cds_caching.CachingApiService.Caches']
+            expect(caches['@readonly']).to.be.true
+        })
+    })
+
+    describe('Caches is not writable over OData', () => {
+
+        it("rejects CREATE", async () => {
+            const call = POST(`${API}/Caches`, { name: 'injected', metricsEnabled: true }, ADMIN)
+            expect(await statusOf(call)).to.be.oneOf([405, 400])
+        })
+
+        it("rejects UPDATE of metricsEnabled", async () => {
+            const call = test.PATCH(`${API}/Caches('caching')`, { metricsEnabled: true }, ADMIN)
+            expect(await statusOf(call)).to.be.oneOf([405, 400])
+        })
+
+        it("rejects DELETE", async () => {
+            const call = test.DELETE(`${API}/Caches('caching')`, ADMIN)
+            expect(await statusOf(call)).to.be.oneOf([405, 400])
+        })
+    })
+
+    describe('Cache name allow-list', () => {
+
+        it("returns 404 for an unknown cache", async () => {
+            expect(await statusOf(GET(`${API}/Caches('nope')/getEntries()`, ADMIN))).to.equal(404)
+        })
+
+        it("refuses to connect to a non-caching service", async () => {
+            // 'db' and 'Northwind' are configured services, but not caches.
+            expect(await statusOf(GET(`${API}/Caches('db')/getEntries()`, ADMIN))).to.equal(404)
+            expect(await statusOf(GET(`${API}/Caches('Northwind')/getEntries()`, ADMIN))).to.equal(404)
+        })
+
+        it("refuses to flush a non-caching service", async () => {
+            expect(await statusOf(POST(`${API}/Caches('db')/clear`, {}, ADMIN))).to.equal(404)
+        })
+
+        it("still serves configured caches", async () => {
+            const { data } = await GET(`${API}/Caches('caching-northwind')/getEntries()`, ADMIN)
+            expect(data.value).to.be.an('array')
+        })
+    })
+
+    describe('Resource limits', () => {
+
+        let cache
+
+        beforeEach(async () => {
+            cache = await cds.connect.to('caching')
+            await cache.clear()
+        })
+
+        it("defaults to at most 100 entries", async () => {
+            for (let i = 0; i < 120; i++) await cache.set(`page:${i}`, `v${i}`)
+
+            const { data } = await GET(`${API}/Caches('caching')/getEntries()`, ADMIN)
+            expect(data.value).to.have.length(100)
+        })
+
+        it("honours top and skip", async () => {
+            for (let i = 0; i < 20; i++) await cache.set(`page:${i}`, `v${i}`)
+
+            const { data: firstPage } = await GET(`${API}/Caches('caching')/getEntries(top=5,skip=0)`, ADMIN)
+            expect(firstPage.value).to.have.length(5)
+
+            const { data: secondPage } = await GET(`${API}/Caches('caching')/getEntries(top=5,skip=5)`, ADMIN)
+            expect(secondPage.value).to.have.length(5)
+
+            const firstKeys = firstPage.value.map(e => e.entryKey)
+            const secondKeys = secondPage.value.map(e => e.entryKey)
+            expect(firstKeys).to.not.have.members(secondKeys)
+        })
+
+        it("caps top at the hard maximum", async () => {
+            for (let i = 0; i < 10; i++) await cache.set(`page:${i}`, `v${i}`)
+
+            // Asking for far more than the cap must not error, just return what exists.
+            const { data } = await GET(`${API}/Caches('caching')/getEntries(top=999999,skip=0)`, ADMIN)
+            expect(data.value).to.have.length(10)
+        })
+
+        it("rejects oversized values", async () => {
+            const tooBig = 'x'.repeat(1024 * 1024 + 1)
+            const call = POST(`${API}/Caches('caching')/setEntry`, { key: 'big', value: tooBig, ttl: 0 }, ADMIN)
+
+            // Over HTTP the body-size limit usually rejects first (413); the handler's
+            // own check (400) is what protects programmatic callers and deployments
+            // that raise the body limit. Either way the value must not be stored.
+            expect(await statusOf(call)).to.be.oneOf([400, 413])
+            expect(await cache.get('big')).to.be.undefined
+        })
+
+        it("rejects oversized values for programmatic callers too", async () => {
+            const api = await cds.connect.to('plugin.cds_caching.CachingApiService')
+            const tooBig = 'x'.repeat(1024 * 1024 + 1)
+
+            const call = cds.tx({ user: adminUser() }, () => api.send({
+                event: 'setEntry',
+                entity: 'Caches',
+                params: [{ name: 'caching' }],
+                data: { key: 'big-programmatic', value: tooBig, ttl: 0 },
+            }))
+
+            await expect(call).to.be.rejectedWith(/exceeds the maximum/)
+            expect(await cache.get('big-programmatic')).to.be.undefined
+        })
+
+        it("accepts values under the limit", async () => {
+            const ok = 'x'.repeat(1000)
+            const { data } = await POST(`${API}/Caches('caching')/setEntry`, { key: 'ok', value: ok, ttl: 0 }, ADMIN)
+            expect(data.value).to.be.true
+        })
+    })
+
+    describe('Dashboard static route guard', () => {
+
+        const { requireAuthenticatedUser, capRequestMiddlewares } = require('../lib/dashboard-guard')
+
+        /** Minimal express-like response recorder. */
+        const fakeRes = () => {
+            const res = {
+                statusCode: null,
+                headers: {},
+                ended: false,
+                status(code) { res.statusCode = code; return res },
+                set(name, value) { res.headers[name] = value; return res },
+                end() { res.ended = true; return res },
+            }
+            return res
+        }
+
+        /** Run the guard with a given cds.context.user, restoring context afterwards. */
+        const runGuard = (user) => {
+            const previous = cds.context
+            try {
+                cds.context = { user }
+                const res = fakeRes()
+                let passed = false
+                requireAuthenticatedUser({}, res, () => { passed = true })
+                return { passed, res }
+            } finally {
+                cds.context = previous
+            }
+        }
+
+        it("passes an authenticated user through", () => {
+            const { passed, res } = runGuard(new cds.User({ id: 'cacheadmin' }))
+            expect(passed).to.be.true
+            expect(res.statusCode).to.be.null
+        })
+
+        it("rejects the anonymous user with 401", () => {
+            const { passed, res } = runGuard(new cds.User.Anonymous())
+            expect(passed).to.be.false
+            expect(res.statusCode).to.equal(401)
+            expect(res.ended).to.be.true
+        })
+
+        it("rejects a missing user with 401", () => {
+            const { passed, res } = runGuard(undefined)
+            expect(passed).to.be.false
+            expect(res.statusCode).to.equal(401)
+        })
+
+        it("challenges with WWW-Authenticate so browsers can prompt", () => {
+            const { res } = runGuard(undefined)
+            expect(res.headers['WWW-Authenticate']).to.match(/Basic realm/)
+        })
+
+        it("exposes CAP's middlewares as a flat list of handlers", () => {
+            const middlewares = capRequestMiddlewares()
+            expect(middlewares).to.be.an('array')
+            expect(middlewares.length).to.be.greaterThan(0)
+            for (const mw of middlewares) expect(mw).to.be.a('function')
+        })
+    })
+
+    describe('Debug response headers', () => {
+
+        const CapOperations = require('../lib/operations/CapOperations')
+        const withOptions = (options) => new CapOperations(null, null, null, console, { options })
+
+        it("is off when unconfigured", () => {
+            expect(withOptions({}).debugHeadersEnabled()).to.be.false
+        })
+
+        it("is off for anything other than an explicit true", () => {
+            expect(withOptions({ debugHeaders: 'true' }).debugHeadersEnabled()).to.be.false
+            expect(withOptions({ debugHeaders: 1 }).debugHeadersEnabled()).to.be.false
+            expect(withOptions({ debugHeaders: false }).debugHeadersEnabled()).to.be.false
+        })
+
+        it("is on when explicitly enabled", () => {
+            expect(withOptions({ debugHeaders: true }).debugHeadersEnabled()).to.be.true
+        })
+
+        it("tolerates a missing runtime config manager", () => {
+            expect(new CapOperations(null, null, null, console, undefined).debugHeadersEnabled()).to.be.false
+        })
+
+        it("emits the cache key only for a cache that opted in", async () => {
+            // The test app sets debugHeaders on 'caching', which CachedFoo uses.
+            const { headers } = await GET('/odata/v4/app/CachedFoo')
+            expect(headers).to.have.property('x-sap-cap-cache-key')
+        })
+    })
+
+    describe('Metrics sanitizing', () => {
+
+        it("redacts credential-bearing headers", () => {
+            const safe = redactHeaders({
+                'Authorization': 'Bearer supersecret',
+                'cookie': 'JSESSIONID=abc',
+                'Set-Cookie': 'x=y',
+                'X-API-Key': 'key123',
+                'x-csrf-token': 'tok',
+                'sap-passport': 'blob',
+                'content-type': 'application/json',
+                'accept-language': 'en',
+            })
+
+            expect(safe.Authorization).to.equal(REDACTED)
+            expect(safe.cookie).to.equal(REDACTED)
+            expect(safe['Set-Cookie']).to.equal(REDACTED)
+            expect(safe['X-API-Key']).to.equal(REDACTED)
+            expect(safe['x-csrf-token']).to.equal(REDACTED)
+            expect(safe['sap-passport']).to.equal(REDACTED)
+
+            // Non-sensitive headers stay intact, so metrics remain useful.
+            expect(safe['content-type']).to.equal('application/json')
+            expect(safe['accept-language']).to.equal('en')
+        })
+
+        it("leaves the original headers untouched", () => {
+            const original = { authorization: 'Bearer secret' }
+            redactHeaders(original)
+            expect(original.authorization).to.equal('Bearer secret')
+        })
+
+        it("handles missing headers", () => {
+            expect(redactHeaders(undefined)).to.be.undefined
+            expect(redactHeaders(null)).to.be.undefined
+        })
+
+        it("truncates long fields and reports how much was cut", () => {
+            const truncated = truncateField('a'.repeat(100), 10)
+            expect(truncated).to.include('[truncated 90 chars]')
+            expect(truncated.startsWith('a'.repeat(10))).to.be.true
+        })
+
+        it("leaves short fields alone", () => {
+            expect(truncateField('short', 10)).to.equal('short')
+            expect(truncateField(undefined, 10)).to.be.undefined
+        })
+
+        it("bounds the free-text metric fields", () => {
+            const metadata = {
+                metadata: 'm'.repeat(50),
+                query: 'q'.repeat(50),
+                subject: 's'.repeat(50),
+                context: 'c'.repeat(50),
+                cacheOptions: 'o'.repeat(50),
+                user: 'alice',
+            }
+
+            const bounded = truncateMetadataFields(metadata, 10)
+
+            for (const field of ['metadata', 'query', 'subject', 'context', 'cacheOptions']) {
+                expect(bounded[field]).to.include('[truncated 40 chars]')
+            }
+            // Short, structured fields pass through unchanged.
+            expect(bounded.user).to.equal('alice')
+        })
+
+        it("returns the same object when nothing needs truncating", () => {
+            const metadata = { query: 'short', user: 'alice' }
+            expect(truncateMetadataFields(metadata, 100)).to.equal(metadata)
+        })
+    })
+})

--- a/test/app/package.json
+++ b/test/app/package.json
@@ -30,6 +30,21 @@
           "url": ":memory:"
         }
       },
+      "auth": {
+        "kind": "mocked",
+        "users": {
+          "cacheadmin": {
+            "password": "cacheadmin",
+            "roles": [
+              "CacheAdmin"
+            ]
+          },
+          "plainuser": {
+            "password": "plainuser",
+            "roles": []
+          }
+        }
+      },
       "caching": {
         "impl": "cds-caching",
         "namespace": "testCache",

--- a/test/app/package.json
+++ b/test/app/package.json
@@ -49,6 +49,7 @@
         "impl": "cds-caching",
         "namespace": "testCache",
         "store": "memory",
+        "debugHeaders": true,
         "metrics": {
           "enabled": true,
           "persistenceInterval": 10000,
@@ -59,6 +60,7 @@
         "impl": "cds-caching",
         "namespace": "northwind",
         "store": "sqlite",
+        "debugHeaders": true,
         "credentials": {
           "url": "file::memory:"
         }


### PR DESCRIPTION
Security hardening for 2.1. Eleven commits, each a single reviewable change.

## What changed

| Commit | Addresses |
| --- | --- |
| `fix(build)`: stop logging `cds.env.requires` during `cds build` | The build log printed every configured service's `credentials` block at INFO |
| `feat(api)`: require an authenticated user for `CachingApiService` | The management API shipped without `@requires`, and `Caches` accepted plain CRUD |
| `feat(api)`: resolve cache names against an allow-list | The cache name from the request key reached `cds.connect.to()` unchecked |
| `feat(api)`: bound `getEntries` and `setEntry` | Unbounded iteration over the whole cache, and values of unlimited size |
| `fix(dashboard)`: serve the reuse dashboard behind CAP's auth | `express.static()` was mounted outside CAP's authentication |
| `fix(metrics)`: redact credentials and bound fields in `KeyMetrics` | Raw `Authorization` and `Cookie` headers were persisted, fields unbounded |
| `feat(cache)`: make `x-sap-cap-cache-key` opt-in | Responses echoed the full cache key to the caller |
| `feat(config)`: warn when `keyManagement` sits outside `cds.requires` | A block in the position the old docs showed was silently ignored |
| `test`: cover the hardened API, dashboard and metrics paths | 38 new tests |
| `docs`: add a security guide and 2.1 upgrade notes | New `docs/security.md`, plus upgrade notes for every behavior change |
| `docs`: document the limits of the key awareness flags | What `isUserAware` and `isLocaleAware` do and do not cover |

## Behavior changes

Three changes will break some callers, all covered in the
[migration guide](docs/migration-guide.md):

- Unauthenticated calls to `/odata/v4/caching-api` now return `401`. The default
  is `authenticated-user`, which consumers can replace with their own role via a
  downstream `annotate` statement. Anyone who already annotated the service is
  unaffected.
- Direct `CREATE`/`UPDATE`/`DELETE` on `Caches` is rejected; the bound actions
  remain the only write path, so `metricsEnabled` and `config` can no longer be
  tampered with through plain CRUD.
- `getEntries` returns at most 100 entries (cap 1000) unless a larger `top` is
  passed, and `x-sap-cap-cache-key` is no longer sent unless `debugHeaders` is
  enabled on the cache.
